### PR TITLE
Do not fail when the body is empty

### DIFF
--- a/src/PayloadHelper.test.ts
+++ b/src/PayloadHelper.test.ts
@@ -17,6 +17,18 @@ describe("PayloadHelper", () => {
         expect(payloadHelper.getBodyFromPayload()).toEqual("test body");
     });
 
+    it("should be able to return empty body for issue without a body", () => {
+        const context: Context<Webhooks.WebhookPayloadIssues> = {
+            payload: {
+                // @ts-ignore
+                issue: {
+                }
+            }
+        };
+        const payloadHelper = new PayloadHelper(context);
+        expect(payloadHelper.getBodyFromPayload()).toEqual("");
+    });
+
     it("should be able to get body for pull request", () => {
         const context: Context<Webhooks.WebhookPayloadPullRequest> = {
             payload: {
@@ -161,5 +173,26 @@ describe("PayloadHelper", () => {
         };
         const payloadHelper = new PayloadHelper(context);
         expect(payloadHelper.getNewBody()).toEqual("created new PR number 2 by cyberhck");
+    });
+
+    describe("getNewBody should be able to render empty body", () => {
+        const context: Context<Webhooks.WebhookPayloadIssues> = {
+            payload: {
+                // @ts-ignore
+                issue: {
+                    number: 2,
+                    labels: []
+                },
+                // @ts-ignore
+                sender: {
+                    avatar_url: "https://github.com/avatar.jpg",
+                    login: "cyberhck",
+                    url: "https://github.com/cyberhck",
+                    id: 12345
+                }
+            }
+        };
+        const payloadHelper = new PayloadHelper(context);
+        expect(payloadHelper.getNewBody()).toEqual("");
     });
 });

--- a/src/PayloadHelper.ts
+++ b/src/PayloadHelper.ts
@@ -76,9 +76,9 @@ export class PayloadHelper implements IPayloadHelper {
     }
 
     public getBodyFromPayload(): string {
-        return PayloadHelper.isPr(this.context.payload)
+        return (PayloadHelper.isPr(this.context.payload)
             ? this.context.payload.pull_request.body
-            : this.context.payload.issue.body;
+            : this.context.payload.issue.body) || "";
     }
 
 }


### PR DESCRIPTION
This prevents an error when the body of the issue/PR is empty.

A body can be empty in this context (read with AND):
* organizations that enabled the app on all their repositories
* repositories that do not use templates
* the body is not defined

The message received is:

```
There was error processing your body
The exact error message is the following

Error: You must pass a string or Handlebars AST to Handlebars.compile. You passed null

at Object.compile (/var/task/node_modules/handlebars/dist/cjs/handlebars/compiler/compiler.js:501:11)
at HandlebarsEnvironment.hb.compile (/var/task/node_modules/handlebars/dist/cjs/handlebars.js:39:40)
at new HandlebarCompiler (/var/task/lib/HandlebarCompiler.js:6:38)
at PayloadHelper.getNewBody (/var/task/lib/PayloadHelper.js:41:24)
at App. (/var/task/lib/App.js:65:54)
at step (/var/task/lib/App.js:32:23)
at Object.next (/var/task/lib/App.js:13:53)
at /var/task/lib/App.js:7:71
at new Promise ()
at __awaiter (/var/task/lib/App.js:3:12)
at App.handleEvent (/var/task/lib/App.js:59:16)
at App.handleEvent (/var/task/lib/App.js:52:20)
at Application. (/var/task/node_modules/probot/lib/application.js:153:50)
at step (/var/task/node_modules/probot/lib/application.js:43:23)
at Object.next (/var/task/node_modules/probot/lib/application.js:24:53)
at fulfilled (/var/task/node_modules/probot/lib/application.js:15:58)
at process._tickCallback (internal/process/next_tick.js:68:7)

This body won't be processed any further, please fix your template.
```

This PR turns an empty body into an empty string making Handlebars happy) and lets the rest of the process unchanged.